### PR TITLE
Adding headers for code blocks, removing powershell.

### DIFF
--- a/src/en/developer-hook-tools.md
+++ b/src/en/developer-hook-tools.md
@@ -12,17 +12,17 @@ individual commands run the command with the -h flag.
 `action-fail` without a failure message will set a default message indicating a
 problem with the action.
 
+python:  
 ```python
 from charmhelpers.core.hookenv import action_fail
 
 action_fail(‘Unable to contact remote service’)
 ```
+bash:  
 ```bash
 action-fail ‘unable to contact remote service’
 ```
-<!-- ```powershell
-# Command Not yet implemented.
-``` -->
+
 
 ## action-get
 
@@ -30,17 +30,17 @@ action-fail ‘unable to contact remote service’
 as YAML.  If multiple keys are passed, `action-get` will recurse into the param
 map as needed.
 
+python:  
 ```python
 from charmhelpers.core.hookenv import action_get
 
 timeout = action_get(‘timeout’)
 ```
+bash:  
 ```bash
 TIMEOUT=$(action-get timeout)
 ```
-<!-- ```powershell
-# Command Not yet implemented.
-``` -->
+
 
 ## action-set
 
@@ -49,44 +49,44 @@ is returned to the user after the completion of the Action.  Keys must start
 and end with lowercase alphanumeric, and contain only lowercase alphanumeric,
 hyphens and periods.
 
-
+python:  
 ```python
 from charmhelpers.core.hookenv import action_set
 
 action_set('com.juju.result', 'we are the champions')
 ```
+bash:  
 ```bash
 action-set com.juju.result 'we are the champions'
 ```
-<!-- ```powershell
-# Command Not yet implemented.
-``` -->
+
 
 ## close-port
 
 `close-port` ensures a port or range is not accessible from the public
 interface.
 
+python:  
 ```python
 from charmhelpers.core.hookenv import close_port
 
 # Close a single port
 close_port(80, protocol="UDP")
 ```
+bash:  
 ```bash
 # Close single port
 close-port 80
 # Close a range of ports
 close-port 9000-9999/udp
 ```
-```powershell
-close-port.exe 80
-```
+
 
 ## config-get
 
 `config-get` prints the service configuration for one key or all keys.
 
+python:  
 ```python
 from charmhelpers.core.hookenv import config
 
@@ -95,12 +95,11 @@ cfg =config()
 # Get the value for the "interval" key.
 interval = cfg.get(‘interval’)
 ```
+bash:  
 ```bash
 INTERVAL=$(config-get interval)
 ```
-```powershell
-$url = config-get.exe --format=json "installer-url"
-```
+
 
 ## is-leader
 
@@ -108,38 +107,38 @@ $url = config-get.exe --format=json "installer-url"
 be service leader for at least 30 seconds. If it fails, you should assume that
 there is no such guarantee.
 
+python:  
 ```python
 from charmhelpers.core.hookenv import is_leader
 
 if is_leader():
     # Do something a leader would do
 ```
+bash:  
 ```bash
 LEADER=$(is-leader)
 if [ "${LEADER}" == "True" ]; then
   # Do something a leader would do
 fi
 ```
-<!-- ```powershell
-# Command Not yet implemented.
-``` -->
+
 
 ## juju-log
 
 `juju-log` writes a message to the juju log at the appropriate log level. Valid
 levels are: INFO, WARN, ERROR, DEBUG
 
+python:  
 ```python
 from charmhelpers.core.hookenv import juju_log
 
 juju_log('Something has transpired', 'INFO')
 ```
+bash:  
 ```bash
 juju-log -l 'INFO' Something has transpired
 ```
-```powershell
-juju-log.exe "Failed to run amqp-relation-broken: $_"
-```
+
 
 ## juju-reboot
 
@@ -157,13 +156,15 @@ The --now flag cannot terminate a debug-hooks session; hooks using --now should
 be sure to terminate on unexpected errors, so as to guarantee expected behavior
 in all situations.
 
-juju-reboot is not supported when running actions.
+`juju-reboot` is not supported when running actions.
 
+python:  
 ```python
 from subprocess import check_call
 
 check_call(["juju-reboot", "--now"])
 ```
+bash:  
 ```bash
 # immediately reboot
 juju-reboot --now
@@ -171,26 +172,24 @@ juju-reboot --now
 # Reboot after current hook exits
 juju-reboot
 ```
-```powershell
-juju-reboot.exe --now
-```
+
 
 ## leader-get
 
 `leader-get` prints the value of a leadership setting specified by key. If no
 key is given, or if the key is "-", all keys and values will be printed.
 
+python:  
 ```python
 from charmhelpers.core.hookenv import leader_get
 
 address = leader_get('cluster-leader-address')
 ```
+bash:  
 ```bash
 ADDRESSS=$(leader-get cluster-leader-address)
 ```
-<!-- ```powershell
-# Command Not yet implemented.
-``` -->
+
 
 ## leader-set
 
@@ -198,50 +197,50 @@ ADDRESSS=$(leader-get cluster-leader-address)
 which will then inform non-leader units of the change. It will fail if called
 without arguments, or if called by a unit that is not currently service leader.
 
+python:  
 ```python
 from charmhelpers.core.hookenv import leader_set
 
 leader_set('cluster-leader-address', "10.0.0.123")
 ```
+bash:  
 ```bash
 leader-set cluster-leader-address=10.0.0.123
 ```
-<!-- ```powershell
-# Command Not yet implemented.
-``` -->
+
 
 ## opened-ports
 
 `opened-ports` lists all ports or ranges opened by the unit.
 
+python:  
 ```python
 from subprocess import check_output
 
 range = check_output(["opened-ports"])
 ```
+bash:  
 ```bash
 opened-ports
 ```
-```powershell
-opened-ports.exe
-```
+
 
 ## open-port
 
 `open-port` registers a port or range to open on the public-interface. On public
 clouds the port will only be open while the service is exposed.
 
+python:  
 ```python
 from charmhelpers.core.hookenv import open_port
 
 open_port(80, protocol='TCP')
 ```
+bash:  
 ```bash
 open-port 80/tcp
 ```
-```powershell
-open-port.exe 80
-```
+
 
 ## payload-register
 
@@ -252,17 +251,17 @@ provided when "register" is run.
 The payload class must correspond to one of the payloads defined in
 the charm's metadata.yaml.
 
+python:  
 ```python
 from subprocess import check_call
 
 check_call(["payload-register", "monitoring", "docker", "0fcgaba"])
 ```
+bash:  
 ```bash
 payload-register monitoring docker 0fcgaba
 ```
-<!-- ```powershell
-# Command Not yet implemented.
-``` -->
+
 
 ## payload-unregister
 
@@ -271,67 +270,67 @@ that a payload has been manually stopped. The <class> and <id> provided
 must match a payload that has been previously registered with juju using
 payload-register.
 
+python:  
 ```python
 from subprocess import check_call
 
 check_call(["payload-unregister", "monitoring", "0fcgaba"])
 ```
+bash:  
 ```bash
 payload-unregister monitoring 0fcgaba
 ```
-<!-- ```powershell
-# Command Not yet implemented.
-``` -->
+
 
 ## relation-get
 
 `relation-get` prints the value of a unit's relation setting, specified by key.
 
+python:  
 ```python
 from charmhelpers.core.hookenv import relation_get
 
 # when in a relationship hook context
 relation_get('private-address')
 ```
+bash:  
 ```bash
 relation-get private-address
 ```
-```powershell
-$ctx["rabbit_host"] = relation-get.exe -attr "private-address" -rid $rid -unit $unit
-```
+
 
 ## relation-ids
 
 `relation-ids` lists all relation id's with the given relation name.
 
+python:  
 ```python
 from charmhelpers.core.hookenv import relation_ids
 
 relation_ids('database')
 ```
+bash:  
 ```bash
 relation-ids database
 ```
-```powershell
-$ids = relation_ids.exe -reltype 'amqp'
-```
+
 
 ## relation-list
 
 `relation-list` lists the units on the relation. Scoped through a relation id.
 
+python:  
 ```python
 from charmhelpers.core.hookenv import relation_list
 from charmhelpers.core.hookenv import relation_id
 
 relation_list(relation_id())
 ```
+bash:  
 ```bash
 relation-list 9
 ```
-```powershell
-$related_units = related-list.exe -r $relationId
-```
+
 
 ## relation-set
 
@@ -340,50 +339,50 @@ is specified then the current relation is used. The setting values are not
 inspected and are stored as strings. Setting an empty string causes the setting
 to be removed.
 
+python:  
 ```python
 from charmhelpers.core.hookenv import relation_set
 
 relation_set({'port': 80, 'tuning': 'default'})
 ```
+bash:  
 ```bash
 relation-set port=80 tuning=default
 ```
-```powershell
-relation-set.exe -r $relid port=80 tuning=default
-```
+
 
 ## status-get
 
 `status-get` prints the previously set state of the workload.
 
+python:  
 ```python
 from charmhelpers.core.hookenv import status_get
 
 charm_status = status_get()
 ```
+bash:  
 ```bash
 status-get
 ```
-<!-- ```powershell
-# Command Not yet implemented.
-``` -->
+
 
 ## status-set
 
 `status-set` wites the workload state with an optional message which is visible
 to the user using `juju status`
 
+python:  
 ```python
 from charmhelpers.core.hookenv import status_set
 
 status_set('blocked', 'Unable to continue until related to a database')
 ```
+bash:  
 ```bash
 status-set blocked 'Unable to continue until related to a database'
 ```
-```powershell
-status-set.exe "active"
-```
+
 
 ## storage-add
 
@@ -392,34 +391,34 @@ A storage directive consists of a storage name as per charm specification and
 optional storage COUNT. COUNT is a positive integer indicating how many
 instances of the storage to create. If unspecified, COUNT defaults to 1.
 
+python:  
 ```python
 from subprocess import check_call
 
 check_call(["storage-add", "database-storage=1"])
 ```
+bash:  
 ```bash
 storage-add database-storage=1
 ```
-<!-- ```powershell
-# Command Not yet implemented.
-``` -->
+
 
 ## storage-get
 
 `stoarge-get` information for storage instance with specified id. When no <key>
 is supplied, all keys values are printed.
 
+python:  
 ```python
 from subprocess import check_call
 
 check_call(["storage-get", "21127934-8986-11e5-af63-feff819cdc9f"])
 ```
+bash:
 ```bash
 storage-get 21127934-8986-11e5-af63-feff819cdc9f
 ```
-<!-- ```powershell
-# Command Not yet implemented.
-``` -->
+
 
 ## storage-list
 
@@ -427,31 +426,30 @@ storage-get 21127934-8986-11e5-af63-feff819cdc9f
 unit. These names can be passed to `storage-get` using the "-s" flag to query
 the storage attributes.
 
+python:  
 ```python
 from subprocess import check_output
 
 storage = check_output(["storage-list"])
 ```
+bash:  
 ```bash
 storage-list
 ```
-<!-- ```powershell
-# Command Not yet implemented.
-``` -->
+
 
 ## unit-get
 
 `unit-get` return the unit specific information requested, such as
 private-address or public-address.
 
+python:  
 ```python
 from charmhelpers.core.hookenv import unit_get
 
 address = unit_get('public-address')
 ```
+bash:  
 ```bash
 unit-get public-address
-```
-```powershell
-unit-get.exe public-address
 ```


### PR DESCRIPTION
At the doc review I was asked to remove the powershell content as it was not _actually_ powershell commands.  Sent an email to our partners at cloudbase for their guidance on powershell charm-helpers.

Added python: and bash: headers above the code blocks so the user can differentiate the two.
