### PR TITLE
Revert "Fix errant leading spaces"

### DIFF
--- a/src/en/developer-layers.md
+++ b/src/en/developer-layers.md
@@ -131,8 +131,8 @@ from charms.reactive import set_state
 set_state('apache.available')
 ```
 
-```bash
-charms.reactive set_state 'apache.available'
+ ```bash
+ charms.reactive set_state 'apache.available'
 ```
 
 And subsequently subscribe to them:


### PR DESCRIPTION
Reverts mbruzek/docs#37

This merge is targeted at the wrong branch.  Should be developer-guide